### PR TITLE
Utility binary to synchronize projector with cameras and capturing fames

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+# sudo apt install clang-format
+# Use the Google style in this project.
+BasedOnStyle: Google
+
+# Some folks prefer to write "int& foo" while others prefer "int &foo".  The
+# Google Style Guide only asks for consistency within a project, we chose
+# "int& foo" for this project:
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# The Google Style Guide only asks for consistency w.r.t. "east const" vs.
+# "const west" alignment of cv-qualifiers. In this project we use "east const".
+QualifierAlignment: Left
+
+IncludeBlocks: Merge
+
+# Format raw string literals with a `pb` or `proto` tag as proto.
+RawStringFormats:
+  - Language: TextProto
+    Delimiters:
+      - 'pb'
+      - 'proto'
+    BasedOnStyle: Google
+
+CommentPragmas: '(@copydoc)'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,48 +1,48 @@
 # For colors
-if(NOT WIN32)
+if (NOT WIN32)
     string(ASCII 27 Esc)
     set(ColourReset "${Esc}[m")
-    set(ColourBold  "${Esc}[1m")
-    set(Red         "${Esc}[31m")
-    set(Green       "${Esc}[32m")
-    set(Yellow      "${Esc}[33m")
-    set(Blue        "${Esc}[34m")
-    set(Magenta     "${Esc}[35m")
-    set(Cyan        "${Esc}[36m")
-    set(White       "${Esc}[37m")
-    set(BoldRed     "${Esc}[1;31m")
-    set(BoldGreen   "${Esc}[1;32m")
-    set(BoldYellow  "${Esc}[1;33m")
-    set(BoldBlue    "${Esc}[1;34m")
+    set(ColourBold "${Esc}[1m")
+    set(Red "${Esc}[31m")
+    set(Green "${Esc}[32m")
+    set(Yellow "${Esc}[33m")
+    set(Blue "${Esc}[34m")
+    set(Magenta "${Esc}[35m")
+    set(Cyan "${Esc}[36m")
+    set(White "${Esc}[37m")
+    set(BoldRed "${Esc}[1;31m")
+    set(BoldGreen "${Esc}[1;32m")
+    set(BoldYellow "${Esc}[1;33m")
+    set(BoldBlue "${Esc}[1;34m")
     set(BoldMagenta "${Esc}[1;35m")
-    set(BoldCyan    "${Esc}[1;36m")
-    set(BoldWhite   "${Esc}[1;37m")
-endif()
+    set(BoldCyan "${Esc}[1;36m")
+    set(BoldWhite "${Esc}[1;37m")
+endif ()
 
 cmake_minimum_required(VERSION 3.5)
-set( CMAKE_EXPORT_COMPILE_COMMANDS 1 )
-project( SLS )
-set (VERSION_MAJOR 4)
-set (VERSION_MINOR 0)
-set (VERSION_PATCH 1)
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+project(SLS)
+set(VERSION_MAJOR 4)
+set(VERSION_MINOR 0)
+set(VERSION_PATCH 1)
 
 
 # Include this project
 include_directories(./src/lib)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-find_package( GLM REQUIRED )
+find_package(GLM REQUIRED)
 include_directories(${GLM_INCLUDE_DIR})
 
 add_definitions(-DGLM_ENABLE_EXPERIMENTAL)
-find_package( OpenCV 4.0 REQUIRED)
+find_package(OpenCV 4.0 REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 #Detecting CUDA
 find_package(CUDA)
 # Set default ENABLE_CUDA value
-option (ENABLE_CUDA "Enable CUDA in build" OFF)
-option (GTEST "Enable Google test in buid" OFF)
+option(ENABLE_CUDA "Enable CUDA in build" OFF)
+option(GTEST "Enable Google test in buid" OFF)
 #if (NOT DEFINED ${ENABLE_CUDA})
 #    if (${CUDA_FOUND})
 #        set(ENABLE_CUDA ON)
@@ -53,26 +53,26 @@ option (GTEST "Enable Google test in buid" OFF)
 #endif (NOT DEFINED ${ENABLE_CUDA})
 
 if (${CUDA_FOUND} AND ${ENABLE_CUDA})
-    set( USE_CUDA ON)
+    set(USE_CUDA ON)
     include_directories(${CUDA_INCLUDE_DIRS})
     set(CUDA_PROPAGATE_HOST_FLAGS OFF)
     list(APPEND CUDA_NVCC_FLAGS "-O2 -std=c++11 -D__STRICT_ANSI__ -D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES")
 else (${CUDA_FOUND} AND ${ENABLE_CUDA})
-    set( USE_CUDA OFF)
+    set(USE_CUDA OFF)
 endif (${CUDA_FOUND} AND ${ENABLE_CUDA})
 
 if (${CUDA_FOUND} AND NOT ${ENABLE_CUDA})
-    message(STATUS "${Yellow}CUDA is available but disabled, use -DENABLE_CUDA=ON to enable CUDA${ColourReset}") 
+    message(STATUS "${Yellow}CUDA is available but disabled, use -DENABLE_CUDA=ON to enable CUDA${ColourReset}")
 endif (${CUDA_FOUND} AND NOT ${ENABLE_CUDA})
 
 if (NOT ${CUDA_FOUND} AND ${ENABLE_CUDA})
-    message(STATUS "${Yellow}CUDA is not found${ColourReset}") 
+    message(STATUS "${Yellow}CUDA is not found${ColourReset}")
 endif (NOT ${CUDA_FOUND} AND ${ENABLE_CUDA})
 
-    
+
 if (${USE_CUDA})
     add_subdirectory(./src/lib/ReconstructorCUDA)
-endif(${USE_CUDA})
+endif (${USE_CUDA})
 
 
 set(CMAKE_CXX_FLAGS "-std=c++20 -g -Wall")
@@ -83,18 +83,18 @@ if (GTEST)
 endif (GTEST)
 
 # Enable code coverage
-option (COVERAGE "Build with coverage test, require GTEST=on" OFF)
+option(COVERAGE "Build with coverage test, require GTEST=on" OFF)
 if (COVERAGE AND GTEST)
-    set (CMAKE_CXX_FLAGS "-std=c++20 -g -O0 -fprofile-arcs -ftest-coverage")
-    set (CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+    set(CMAKE_CXX_FLAGS "-std=c++20 -g -O0 -fprofile-arcs -ftest-coverage")
+    set(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
     set(CMAKE_EXE_LINKER_FLAGS="-fprofile-arcs -ftest-coverage")
-endif()
+endif ()
 
 # Enable documentation
-option (BUILD_DOC "Build documentation" OFF)
+option(BUILD_DOC "Build documentation" OFF)
 if (BUILD_DOC)
     add_subdirectory("./doc")
-endif(BUILD_DOC)
+endif (BUILD_DOC)
 
 
 add_subdirectory(./src/lib/GrayCode)
@@ -103,10 +103,10 @@ add_subdirectory(./src/lib/core)
 add_subdirectory(./src/app)
 
 
-set_target_properties ( SLS
-    PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    )
+set_target_properties(SLS
+        PROPERTIES
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,17 +1,20 @@
+set(ABSL_PROPAGATE_CXX_STD ON)
+
 aux_source_directory(. SOURCES)
 add_executable(SLS App.cpp)
-target_link_libraries( SLS core)
+target_link_libraries(SLS core)
 
-IF(${USE_CUDA})
+
+IF (${USE_CUDA})
     cuda_add_executable(SLS_GPU ./App_CUDA.cu)
     target_link_libraries(SLS_GPU core sls_gpu)
-    set_target_properties ( SLS_GPU
-        PROPERTIES
-        #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-        #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-        )
-ENDIF(${USE_CUDA})
+    set_target_properties(SLS_GPU
+            PROPERTIES
+            #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+            #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+ENDIF (${USE_CUDA})
 
 add_executable(calibrateCamera CalibrateCamera.cpp)
 target_link_libraries(calibrateCamera core sls_calib)
@@ -19,21 +22,48 @@ target_link_libraries(calibrateCamera core sls_calib)
 add_executable(generateGraycode generateGraycode.cpp)
 target_link_libraries(generateGraycode core sls_graycode)
 
-set_target_properties ( SLS
-    PROPERTIES
-    #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    )
-set_target_properties ( calibrateCamera
-    PROPERTIES
-    #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    )
-set_target_properties ( generateGraycode
-    PROPERTIES
-    #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    )
+add_executable(sync_main sync_main.cc)
+target_link_libraries(sync_main core core absl::base
+        sls_graycode
+        absl::strings
+        absl::status absl::statusor absl::flags
+        absl::flags_parse
+        absl::log
+        absl::log_initialize
+        absl::check)
+
+set_target_properties(SLS
+        PROPERTIES
+        #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_target_properties(calibrateCamera
+        PROPERTIES
+        #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_target_properties(generateGraycode
+        PROPERTIES
+        #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_target_properties(sync_main
+        PROPERTIES
+        #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
+include(FetchContent)
+
+# Abseil
+FetchContent_Declare(
+        abseil
+        GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+        GIT_TAG 20260107.1
+)
+FetchContent_MakeAvailable(abseil)
+

--- a/src/app/sync_main.cc
+++ b/src/app/sync_main.cc
@@ -1,0 +1,153 @@
+// Utility to project gray code patterns, synchronize cameras and saving frames.
+#include <filesystem>
+#include "GrayCode/GrayCode.hpp"
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "opencv2/opencv.hpp"
+
+ABSL_FLAG(int32_t, left_cam, 0, "Left camera ID");
+ABSL_FLAG(int32_t, right_cam, 2, "Right camera ID");
+ABSL_FLAG(std::string, left_cam_dir, "/tmp/left_cam/dataset1",
+          "Directory of the left cam");
+ABSL_FLAG(std::string, right_cam_dir, "/tmp/right_cam/dataset1",
+          "Directory of the right cam");
+
+absl::Status ConfigureCamera(cv::VideoCapture& cap) {
+  cap.set(cv::CAP_PROP_FRAME_WIDTH, 1920);
+  cap.set(cv::CAP_PROP_EXPOSURE, -6);
+  cap.set(cv::CAP_PROP_AUTOFOCUS, 0);
+}
+
+absl::StatusOr<cv::Mat> GetFrame(cv::VideoCapture& cap,
+                                 size_t flush_count = 5) {
+  cv::Mat frame;
+  for (size_t i = 0; i < flush_count; ++i) {
+    if (!cap.grab()) {
+      return absl::InternalError("Failed to grab frames.");
+    }
+  }
+  if (!cap.retrieve(frame)) {
+    return absl::InternalError("Failed to retrieve frame.");
+  }
+  return frame;
+}
+
+absl::Status SaveFrame(const cv::Mat& frame, const std::filesystem::path& dir,
+                       std::string_view filename) {
+  std::filesystem::path file_path = dir / filename;
+  if (!cv::imwrite(file_path.string(), frame)) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to save frame to '%s'.", file_path.string()));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status CapturePair(cv::VideoCapture& left_cap,
+                         cv::VideoCapture& right_cap,
+                         const std::filesystem::path& left_dir,
+                         const std::filesystem::path& right_dir, size_t i,
+                         size_t flush_count = 10) {
+  cv::Mat frame;
+  absl::StatusOr<cv::Mat> frame_or;
+  if (frame_or = GetFrame(left_cap, flush_count); !frame_or.ok()) {
+    return frame_or.status();
+  }
+  frame = frame_or.value();
+  if (auto status = SaveFrame(frame, left_dir, absl::StrFormat("%04d.jpg", i));
+      !status.ok()) {
+    return status;
+  }
+  if (frame_or = GetFrame(left_cap, flush_count); !frame_or.ok()) {
+    return frame_or.status();
+  }
+  frame = frame_or.value();
+  if (auto status = SaveFrame(frame, right_dir, absl::StrFormat("%04d.jpg", i));
+      !status.ok()) {
+    return status;
+  }
+  if (frame_or = GetFrame(left_cap); !frame_or.ok()) {
+    return frame_or.status();
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Run() {
+  // Create output directories if they do not exist.
+  if (!std::filesystem::exists(absl::GetFlag(FLAGS_left_cam_dir))) {
+    if (!std::filesystem::create_directories(absl::GetFlag(FLAGS_left_cam_dir)))
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Failed to create '%s directory.",
+                          absl::GetFlag(FLAGS_left_cam_dir)));
+  }
+  std::filesystem::path left_dir(absl::GetFlag(FLAGS_left_cam_dir));
+  if (!std::filesystem::exists(absl::GetFlag(FLAGS_right_cam_dir))) {
+    if (!std::filesystem::create_directories(
+            absl::GetFlag(FLAGS_right_cam_dir)))
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Failed to create '%s' directory.",
+                          absl::GetFlag(FLAGS_right_cam_dir)));
+  }
+  std::filesystem::path right_dir(absl::GetFlag(FLAGS_right_cam_dir));
+  // Set up gray code
+  const auto kSize = cv::Size(1920, 1080);
+  SLS::GrayCode gc(kSize.width, kSize.height);
+  const std::vector<cv::Mat> images = gc.generateGrayCode();
+  CHECK(images.size() > 0);
+  LOG(INFO) << absl::StreamFormat(
+      "Projector size: %ix%i, number of patterns: %i", kSize.width,
+      kSize.height, images.size());
+  // Set up projector window.
+  constexpr std::string_view win_name = "Setup Window";
+  cv::namedWindow(win_name.data(), cv::WINDOW_NORMAL);
+  LOG(INFO) << "Move window to display/projector. Press any key to "
+               "continue or 'q' to exit.";
+  cv::imshow(win_name.data(), images[0]);
+  if (cv::waitKey(0) == 'q') {
+    return absl::OkStatus();
+  }
+  // Start capturing.
+  cv::VideoCapture left_cap;
+  cv::VideoCapture right_cap;
+  for (size_t i = 0; i < images.size(); ++i) {
+    cv::setWindowProperty(win_name.data(), cv::WND_PROP_FULLSCREEN,
+                          cv::WINDOW_FULLSCREEN);
+    cv::imshow(win_name.data(), images[i]);
+    if (i == 0) {
+      // Starting cameras
+      left_cap.open(absl::GetFlag(FLAGS_left_cam));
+      if (!left_cap.isOpened()) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Failed to open left camera: %i", absl::GetFlag(FLAGS_left_cam)));
+      }
+      right_cap.open(absl::GetFlag(FLAGS_right_cam));
+      if (!right_cap.isOpened()) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Failed to open right camera: %i", absl::GetFlag(FLAGS_right_cam)));
+      }
+     }
+    if (cv::waitKey(/*delay=*/0) == 'q') break;
+    if (auto status = CapturePair(left_cap, right_cap, left_dir, right_dir, i);
+        !status.ok()) {
+      return status;
+    }
+  }
+  LOG(INFO) << absl::StreamFormat("Saved %d frames into %s and %s",
+                                  images.size(), left_dir.string(),
+                                  right_dir.string());
+  return absl::OkStatus();
+}
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  if (const auto status = Run(); !status.ok()) {
+    LOG(ERROR) << status.message();
+    return EXIT_FAILURE;
+  }
+  LOG(INFO) << "Done";
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
It is a new binary to manually sync projectors patterns and saves both camera frames. Requires a projector and two cameras. Without projector to camera hardware synchronization the only reliable way to capture the sequence of patterns and saving them is through manual sync. You would have to click keyboard keys for 20-40 patterns but this seems to be the most reliable way.

This also comes with more moderate tooling and especially Abseil library and more modern C++ patterns. 