### PR TITLE
[ROCm] Add AMD GPU support to the GPU reconstructor

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -1,0 +1,64 @@
+name: ROCm build (HIP)
+
+# Compile-only build of the GPU reconstructor with HIP for AMD GPUs. GitHub's
+# hosted runners have no AMD GPU, so this job configures and builds SLS_GPU but
+# does not run it -- mirroring how the CUDA CI (c-cpp.yml) build-checks without
+# executing on device. The steps below double as a reference for configuring
+# ROCm/HIP on a local machine: install ROCm, then point CMake at the HIP
+# compiler with -DUSE_HIP=ON and a target GPU architecture.
+
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+  workflow_dispatch:
+
+jobs:
+  build-hip:
+
+    runs-on: ubuntu-latest
+
+    # rocm/dev-ubuntu-24.04:*-complete ships the full ROCm toolkit (HIP compiler
+    # at /opt/rocm/llvm/bin/clang++, runtime, and roc*/hip* libraries) on top of
+    # Ubuntu 24.04. On a local machine, install ROCm from
+    # https://rocm.docs.amd.com/ instead of using this container.
+    container:
+      image: rocm/dev-ubuntu-24.04:7.2.4-complete
+
+    steps:
+    # actions/checkout needs git to do a real clone (and to fetch submodules);
+    # the ROCm dev image does not ship it, so install it before checkout.
+    - name: Install checkout prerequisites
+      run: |
+        apt-get update
+        apt-get install -y git
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    # Same host dependencies the CUDA build needs: GLM, OpenCV 4, libtiff, plus
+    # CMake and a host C++ compiler. The container runs as root, so no sudo.
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get install -y cmake build-essential git \
+          libglm-dev libopencv-dev libtiff-dev
+
+    # Configure for AMD GPUs. -DUSE_HIP=ON selects the HIP GPU backend (the
+    # default ENABLE_CUDA / NVIDIA path stays off). CMAKE_HIP_ARCHITECTURES pins
+    # the target GPU (gfx90a = CDNA2 / MI200; use gfx1100 for RDNA3, etc.); it is
+    # set explicitly here because the runner has no GPU to auto-detect.
+    - name: Configure (HIP)
+      run: |
+        cmake -S . -B build \
+          -DUSE_HIP=ON \
+          -DCMAKE_HIP_ARCHITECTURES=gfx90a \
+          -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
+          -DCMAKE_BUILD_TYPE=Release
+
+    # Build the GPU reconstructor only. Compilation succeeding proves the HIP
+    # port builds for the target architecture; no GPU is required.
+    - name: Build SLS_GPU
+      run: cmake --build build --target SLS_GPU -j"$(nproc)"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ YCM-Generator
 .idea
 data
 
+build_ci_check/
+build_hip/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,42 +37,56 @@ include_directories(${GLM_INCLUDE_DIR})
 add_definitions(-DGLM_ENABLE_EXPERIMENTAL)
 find_package(OpenCV 4.0 REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
+# On Windows the prebuilt OpenCV uses include/opencv2/ but sources include
+# <opencv4/opencv2/...> (the Linux /usr/include/opencv4 layout). Provide
+# a compat dir where opencv4/ maps to the actual include root.
+if(WIN32 AND DEFINED OPENCV4_COMPAT_DIR)
+    include_directories(${OPENCV4_COMPAT_DIR})
+endif()
 
-#Detecting CUDA
-find_package(CUDA)
-# Set default ENABLE_CUDA value
-option(ENABLE_CUDA "Enable CUDA in build" OFF)
-option(GTEST "Enable Google test in buid" OFF)
-#if (NOT DEFINED ${ENABLE_CUDA})
-#    if (${CUDA_FOUND})
-#        set(ENABLE_CUDA ON)
-#    else (${CUDA_FOUND})
-#        set(ENABLE_CUDA OFF)
-#    endif(${CUDA_FOUND})
-#    message( "CUDA not defined")
-#endif (NOT DEFINED ${ENABLE_CUDA})
+# GPU backend selection: NVIDIA via ENABLE_CUDA (legacy FindCUDA), AMD via
+# USE_HIP (first-class HIP language). USE_GPU gates the shared GPU targets.
+option (ENABLE_CUDA "Enable CUDA in build" OFF)
+option (USE_HIP "Build the GPU reconstructor with HIP for AMD GPUs" OFF)
+option (GTEST "Enable Google test in buid" OFF)
+set( USE_CUDA OFF)
+set( USE_GPU OFF)
 
-if (${CUDA_FOUND} AND ${ENABLE_CUDA})
-    set(USE_CUDA ON)
-    include_directories(${CUDA_INCLUDE_DIRS})
-    set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-    list(APPEND CUDA_NVCC_FLAGS "-O2 -std=c++11 -D__STRICT_ANSI__ -D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES")
-else (${CUDA_FOUND} AND ${ENABLE_CUDA})
-    set(USE_CUDA OFF)
-endif (${CUDA_FOUND} AND ${ENABLE_CUDA})
+if (USE_HIP)
+    enable_language(HIP)
+    # Default the arch only when unset; never hardcode a literal here, or
+    # -DCMAKE_HIP_ARCHITECTURES is overridden and every target arch must edit
+    # this file.
+    if (NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
+        set(CMAKE_HIP_ARCHITECTURES "gfx90a")
+    endif()
+    set( USE_GPU ON)
+    add_definitions(-DUSE_HIP)
+    message(STATUS "${Green}Building GPU reconstructor with HIP for ${CMAKE_HIP_ARCHITECTURES}${ColourReset}")
+else (USE_HIP)
+    #Detecting CUDA
+    find_package(CUDA)
+    if (${CUDA_FOUND} AND ${ENABLE_CUDA})
+        set( USE_CUDA ON)
+        set( USE_GPU ON)
+        include_directories(${CUDA_INCLUDE_DIRS})
+        set(CUDA_PROPAGATE_HOST_FLAGS OFF)
+        list(APPEND CUDA_NVCC_FLAGS "-O2 -std=c++11 -D__STRICT_ANSI__ -D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES")
+    endif (${CUDA_FOUND} AND ${ENABLE_CUDA})
 
-if (${CUDA_FOUND} AND NOT ${ENABLE_CUDA})
-    message(STATUS "${Yellow}CUDA is available but disabled, use -DENABLE_CUDA=ON to enable CUDA${ColourReset}")
-endif (${CUDA_FOUND} AND NOT ${ENABLE_CUDA})
+    if (${CUDA_FOUND} AND NOT ${ENABLE_CUDA})
+        message(STATUS "${Yellow}CUDA is available but disabled, use -DENABLE_CUDA=ON to enable CUDA${ColourReset}")
+    endif (${CUDA_FOUND} AND NOT ${ENABLE_CUDA})
 
-if (NOT ${CUDA_FOUND} AND ${ENABLE_CUDA})
-    message(STATUS "${Yellow}CUDA is not found${ColourReset}")
-endif (NOT ${CUDA_FOUND} AND ${ENABLE_CUDA})
+    if (NOT ${CUDA_FOUND} AND ${ENABLE_CUDA})
+        message(STATUS "${Yellow}CUDA is not found${ColourReset}")
+    endif (NOT ${CUDA_FOUND} AND ${ENABLE_CUDA})
+endif (USE_HIP)
 
 
-if (${USE_CUDA})
+if (${USE_GPU})
     add_subdirectory(./src/lib/ReconstructorCUDA)
-endif (${USE_CUDA})
+endif(${USE_GPU})
 
 
 set(CMAKE_CXX_FLAGS "-std=c++20 -g -Wall")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,9 @@ set( USE_CUDA OFF)
 set( USE_GPU OFF)
 
 if (USE_HIP)
+    # enable_language(HIP) honors -DCMAKE_HIP_ARCHITECTURES, else auto-detects the
+    # host GPU, else errors on a no-GPU host.
     enable_language(HIP)
-    # Default the arch only when unset; never hardcode a literal here, or
-    # -DCMAKE_HIP_ARCHITECTURES is overridden and every target arch must edit
-    # this file.
-    if (NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
-        set(CMAKE_HIP_ARCHITECTURES "gfx90a")
-    endif()
     set( USE_GPU ON)
     add_definitions(-DUSE_HIP)
     message(STATUS "${Green}Building GPU reconstructor with HIP for ${CMAKE_HIP_ARCHITECTURES}${ColourReset}")

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ If CUDA is detected in your system, the cmake flag `ENABLE_CUDA` is set to `on` 
 
 You can use `cmake .. -DENABLE_CUDA=off` to disable CUDA if you don't want compile the GPU binary.
 
+To build the GPU reconstructor for AMD GPUs instead of NVIDIA, configure with `-DUSE_HIP=ON` and set the target architecture via `CMAKE_HIP_ARCHITECTURES` (for example `gfx90a` for CDNA2 / MI200, or `gfx1100` for RDNA3). This requires a [ROCm](https://rocm.docs.amd.com/) installation (7.2 or newer) providing HIP:
+```
+mkdir build && cd build
+cmake .. -DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx90a
+make
+```
+The default `ENABLE_CUDA` (NVIDIA) path is unchanged.
+
 ### Enable test
 A test using [Google Test Framework](https://github.com/google/googletest.git) is included in the build. To use the test, enable `GTEST` flag at configuration stage.
 ```bash

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -4,17 +4,24 @@ aux_source_directory(. SOURCES)
 add_executable(SLS App.cpp)
 target_link_libraries(SLS core)
 
-
-IF (${USE_CUDA})
-    cuda_add_executable(SLS_GPU ./App_CUDA.cu)
+IF(${USE_GPU})
+    if (USE_HIP)
+        set_source_files_properties(./App_CUDA.cu PROPERTIES LANGUAGE HIP)
+        add_executable(SLS_GPU ./App_CUDA.cu)
+        set_target_properties(SLS_GPU PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+        target_compile_features(SLS_GPU PRIVATE cxx_std_17)
+        target_compile_options(SLS_GPU PRIVATE -include ${CMAKE_SOURCE_DIR}/src/lib/ReconstructorCUDA/cuda_to_hip.h)
+    else (USE_HIP)
+        cuda_add_executable(SLS_GPU ./App_CUDA.cu)
+    endif (USE_HIP)
     target_link_libraries(SLS_GPU core sls_gpu)
-    set_target_properties(SLS_GPU
-            PROPERTIES
-            #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-            #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    )
-ENDIF (${USE_CUDA})
+    set_target_properties ( SLS_GPU
+        PROPERTIES
+        #ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        #LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+        )
+ENDIF(${USE_GPU})
 
 add_executable(calibrateCamera CalibrateCamera.cpp)
 target_link_libraries(calibrateCamera core sls_calib)

--- a/src/lib/ReconstructorCUDA/CMakeLists.txt
+++ b/src/lib/ReconstructorCUDA/CMakeLists.txt
@@ -1,8 +1,21 @@
-message(STATUS "CUDA found, generating sls_gpu")
-file(GLOB CUDA_SOURCES
-    "./*"
-    )
-#cuda_compile(SLS_OBJ ${CUDA_SOURCES})
-cuda_add_library( sls_gpu ${CUDA_SOURCES})
-target_link_libraries( sls_gpu core)
-
+if (USE_HIP)
+    message(STATUS "Generating sls_gpu (HIP)")
+    file(GLOB HIP_SOURCES "./*.cu")
+    set_source_files_properties(${HIP_SOURCES} PROPERTIES LANGUAGE HIP)
+    add_library( sls_gpu ${HIP_SOURCES})
+    set_target_properties( sls_gpu PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+    target_compile_features( sls_gpu PRIVATE cxx_std_17)
+    target_include_directories( sls_gpu PRIVATE ${CMAKE_SOURCE_DIR}/src/lib)
+    # Force-include the compat header before GLM so the GLM device-qualifier
+    # override (see cuda_to_hip.h) is in effect in every HIP translation unit.
+    target_compile_options( sls_gpu PRIVATE -include ${CMAKE_CURRENT_SOURCE_DIR}/cuda_to_hip.h)
+    target_link_libraries( sls_gpu core)
+else (USE_HIP)
+    message(STATUS "CUDA found, generating sls_gpu")
+    file(GLOB CUDA_SOURCES
+        "./*"
+        )
+    #cuda_compile(SLS_OBJ ${CUDA_SOURCES})
+    cuda_add_library( sls_gpu ${CUDA_SOURCES})
+    target_link_libraries( sls_gpu core)
+endif (USE_HIP)

--- a/src/lib/ReconstructorCUDA/CUDA_Error.cuh
+++ b/src/lib/ReconstructorCUDA/CUDA_Error.cuh
@@ -2,7 +2,7 @@
  * CUDA error handling class
  */
 #pragma once
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 #include <core/Log.hpp>
 #define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
 inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)

--- a/src/lib/ReconstructorCUDA/DynamicBits.cuh
+++ b/src/lib/ReconstructorCUDA/DynamicBits.cuh
@@ -85,7 +85,7 @@ struct Dynamic_Bitset_Array_GPU
         if (bitsPerElem > sizeof(uint)*BITS_PER_BYTE)   // Break if longer than uint
         {
             __threadfence();
-            asm("trap;");
+            __builtin_trap();   // portable: NVPTX `asm("trap;")` is illegal on amdgcn
         }
         unsigned char *e = &bits[(elem * bitsPerElem)/BITS_PER_BYTE];
         unsigned int res = 0;

--- a/src/lib/ReconstructorCUDA/FileReaderCUDA.cu
+++ b/src/lib/ReconstructorCUDA/FileReaderCUDA.cu
@@ -1,6 +1,8 @@
 
 #include "FileReaderCUDA.cuh"
-#include <device_launch_parameters.h>
+#if !defined(USE_HIP) && !defined(__HIP_PLATFORM_AMD__)
+#include <device_launch_parameters.h>  // NVIDIA-only; HIP defines these builtins intrinsically
+#endif
 
 namespace SLS
 {
@@ -65,7 +67,7 @@ void FileReaderCUDA::computeShadowsAndThresholds()
 }
 
 void FileReaderCUDA::loadConfig(const std::string& configFile){
-    FileReader::loadConfig(configFile);
+    ImageFileProcessor::loadConfig(configFile);
     // Copy config file to GPU
     float tmpVal[9];
 

--- a/src/lib/ReconstructorCUDA/FileReaderCUDA.cuh
+++ b/src/lib/ReconstructorCUDA/FileReaderCUDA.cuh
@@ -1,10 +1,15 @@
 #pragma once
-#include <core/FileReader.h>
+// Upstream renamed the camera base Camera -> ImageProcessor and FileReader ->
+// ImageFileProcessor, but left this GPU camera pointing at the deleted
+// core/FileReader.h / FileReader base, so the CUDA path no longer compiled on
+// any backend. Repoint it at the current concrete base ImageFileProcessor,
+// which supplies every accessor this class and the kernels use.
+#include <core/ImageFileProcessor.h>
 #include "DynamicBits.cuh"
 #include <string>
 namespace SLS
 {
-class FileReaderCUDA: public FileReader
+class FileReaderCUDA: public ImageFileProcessor
 {
 protected:
     Dynamic_Bitset_Array *maskGPU_; // Sorry can't init before reading the images
@@ -16,8 +21,8 @@ protected:
 
 public:
     FileReaderCUDA()=delete; 
-    FileReaderCUDA(const std::string& cName): 
-        FileReader(cName), maskGPU_(nullptr){
+    FileReaderCUDA(const std::string& cName):
+        ImageFileProcessor(cName), maskGPU_(nullptr){
             gpuErrchk( cudaMalloc((void**)&params_d_[CAMERA_MAT], sizeof(float)*9));
             gpuErrchk( cudaMalloc((void**)&params_d_[DISTOR_MAT], sizeof(float)*5));
             gpuErrchk( cudaMalloc((void**)&params_d_[ROT_MAT], sizeof(float)*9));

--- a/src/lib/ReconstructorCUDA/ReconstructorCUDA.cu
+++ b/src/lib/ReconstructorCUDA/ReconstructorCUDA.cu
@@ -1,11 +1,12 @@
-#include <device_launch_parameters.h>
+#if !defined(USE_HIP) && !defined(__HIP_PLATFORM_AMD__)
+#include <device_launch_parameters.h>  // NVIDIA-only; HIP defines these builtins intrinsically
+#endif
 #include "ReconstructorCUDA.cuh"
 #include "FileReaderCUDA.cuh"
 namespace SLS
 {
 
-ReconstructorCUDA :: ReconstructorCUDA(const size_t projX, const size_t projY): 
-    Reconstructor()
+ReconstructorCUDA :: ReconstructorCUDA(const size_t projX, const size_t projY)
 {
     projector_ = new Projector(projX, projY);
 }

--- a/src/lib/ReconstructorCUDA/ReconstructorCUDA.cuh
+++ b/src/lib/ReconstructorCUDA/ReconstructorCUDA.cuh
@@ -1,5 +1,6 @@
 #pragma once
-#include <core/Reconstructor.h>
+#include <core/ImageProcessor.h>
+#include <core/Projector.h>
 #include <core/Log.hpp>
 #include "DynamicBits.cuh"
 #include <vector>
@@ -7,14 +8,23 @@
 
 namespace SLS
 {
-class ReconstructorCUDA: public Reconstructor
+// The GPU reconstructor runs its own on-device pipeline (build buckets from the
+// cameras, then triangulate), so it owns its cameras and projector directly.
+// Upstream refactored the CPU-side Reconstructor base into a pure interface that
+// takes pre-built Buckets and renamed Camera -> ImageProcessor; this GPU class
+// is a standalone parallel pipeline rather than an implementation of that
+// interface. ImageProcessor is the renamed Camera base.
+using Camera = ImageProcessor;
+class ReconstructorCUDA
 {
 private:
+    std::vector<Camera*> cameras_;
+    Projector* projector_;
 public:
      ReconstructorCUDA(const size_t projX, const size_t projY);
-    ~ReconstructorCUDA() override;
-    void addCamera(Camera *cam) override;
-    PointCloud reconstruct() override;
+    ~ReconstructorCUDA();
+    void addCamera(Camera *cam);
+    PointCloud reconstruct();
 };
 
 struct GPUBucketsObj

--- a/src/lib/ReconstructorCUDA/cuda_to_hip.h
+++ b/src/lib/ReconstructorCUDA/cuda_to_hip.h
@@ -1,0 +1,61 @@
+// CUDA-to-HIP compatibility shim. The single file that knows about HIP.
+// On AMD (USE_HIP) it aliases the small CUDA surface this project uses to the
+// HIP runtime; on NVIDIA it is a plain include of the CUDA runtime. Every other
+// source keeps the CUDA spelling (cudaXxx, atomicInc, ...).
+#pragma once
+
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+
+// Include libc string/memory decls BEFORE the HIP runtime so host memcpy/memset
+// (used inside device helpers in this project) keep their libc decls; once
+// <hip/hip_runtime.h> is in scope these names also gain __device__ overloads.
+#include <cstring>
+#include <cstdlib>
+
+#include <hip/hip_runtime.h>
+
+// GLM 0.9.9 only emits __host__ __device__ on its math functions (dot, length,
+// normalize, mat*vec, ...) when it detects the NVIDIA CUDA compiler. It keys
+// that on __CUDACC__ + CUDA_VERSION (glm/simd/platform.h), which hipcc/clang
+// does not define, so by default every glm:: function is host-only and the
+// device kernels here fail to compile. GLM is included (transitively via
+// core/*.h and <glm/glm.hpp>) only AFTER this header, which is force-included
+// first on the HIP targets, and AFTER <hip/hip_runtime.h> above is fully parsed.
+// Defining these here steers GLM into its CUDA code path so its qualifier macro
+// GLM_CUDA_FUNC_DEF expands to `__device__ __host__`, matching how a CUDA build
+// of this project gets device-callable glm. GLM_FORCE_CUDA stops GLM from
+// pulling in <cuda.h> to discover CUDA_VERSION.
+#if !defined(__CUDACC__)
+#define __CUDACC__ 1
+#endif
+#if !defined(CUDA_VERSION)
+#define CUDA_VERSION 8000
+#endif
+#define GLM_FORCE_CUDA
+
+// Error / status
+#define cudaError_t            hipError_t
+#define cudaSuccess            hipSuccess
+#define cudaGetErrorString     hipGetErrorString
+#define cudaPeekAtLastError    hipPeekAtLastError
+
+// Memory
+#define cudaMalloc             hipMalloc
+#define cudaFree               hipFree
+#define cudaMemcpy             hipMemcpy
+#define cudaMemset             hipMemset
+#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+
+// Events (used for profiling timing only)
+#define cudaEvent_t            hipEvent_t
+#define cudaEventCreate        hipEventCreate
+#define cudaEventRecord        hipEventRecord
+#define cudaEventSynchronize   hipEventSynchronize
+#define cudaEventElapsedTime   hipEventElapsedTime
+
+#else
+
+#include <cuda_runtime.h>
+
+#endif


### PR DESCRIPTION
This adds AMD GPU support (ROCm/HIP) to the GPU structured-light reconstructor (`ReconstructorCUDA`), behind a new CMake `USE_HIP` option (default `OFF`, so the existing CUDA path is unchanged). On `USE_HIP=ON` the build does `enable_language(HIP)`, compiles the existing `.cu` sources as HIP, and force-includes a small compat header.

The CUDA surface here is small and clean -- `cudaMalloc`/`Free`/`Memcpy`/`Memset`, `atomicInc`, `__threadfence`, error helpers, and event-based profiling; no warp intrinsics, textures, or cuRAND/cuBLAS/cuFFT/Thrust -- so the kernels are wave-size-agnostic and port without per-arch changes.

What changed:
- `src/lib/ReconstructorCUDA/cuda_to_hip.h` (new): on `USE_HIP` it includes `<hip/hip_runtime.h>` and aliases the small `cuda*` surface to `hip*`; otherwise it includes `<cuda_runtime.h>` as before. Force-included via CMake `-include` on the HIP targets only.
- `DynamicBits.cuh`: the NVPTX-only `asm("trap;")` (illegal on amdgcn) becomes the portable `__builtin_trap()`. It is a never-taken overflow guard, so output is unaffected on either backend.
- The NVIDIA-only `<device_launch_parameters.h>` include is guarded behind `!USE_HIP` (HIP provides those builtins intrinsically).
- CMake: a `USE_HIP` option and arch from `${CMAKE_HIP_ARCHITECTURES}`; the CUDA branch keeps `cuda_add_*` unchanged.
- One GLM detail: GLM only marks its math `__host__ __device__` when it detects the NVIDIA toolchain (`__CUDACC__` + `CUDA_VERSION`), which hipcc/clang does not define, so the device triangulation helpers fail to compile. The compat header defines `__CUDACC__`/`CUDA_VERSION`/`GLM_FORCE_CUDA` after the HIP runtime is parsed, steering GLM into its CUDA path so its functions become device-callable -- the same way a CUDA build gets device-callable GLM.

It also repairs pre-existing bit-rot in the GPU reconstructor: `FileReaderCUDA`/`ReconstructorCUDA` referenced classes that had been renamed (`FileReader` -> `ImageFileProcessor`) and a `Reconstructor` base later reduced to a pure interface, so the GPU path did not compile against the current tree on stock CUDA either. The fix is minimal and host-side (repoint to `ImageFileProcessor`; make `ReconstructorCUDA` standalone), so the GPU pipeline now builds on both CUDA and HIP.

Building on AMD GPUs:
```
cmake -S . -B build_hip -DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx90a -DGTEST=ON
cmake --build build_hip -j$(nproc)
```

Test Plan:

Validated on AMD Instinct MI250X (gfx90a, CDNA2 wave64), Radeon Pro W7800 (gfx1100, RDNA3 wave32), Radeon PRO V710 (gfx1101, RDNA3 wave32, Windows), and Radeon RX 9070 XT (gfx1201, RDNA4 wave32, Windows), against the shipped `alexander` dataset.

- GPU reconstruction is numerically identical to the CPU reference on every platform: the same 146064 points, 100% nearest-neighbor correspondence both directions (mean ~3.7e-5 world units, far inside the project's MAX_DIFF=10 tolerance), no NaN/Inf.
- Deterministic run-to-run (same point set; only last-ASCII-digit jitter from atomicInc bucket-fill ordering, below the PLY print precision).
- The CPU gtest suite (`RunCPUTest.Arch`, `RunCPUTest.Alexander`) passes -- no regression in the non-GPU path.

Authored with the assistance of Claude (Anthropic).
